### PR TITLE
Fix namespace collision

### DIFF
--- a/src/Autofac.Extras.NLog/NLogModule.cs
+++ b/src/Autofac.Extras.NLog/NLogModule.cs
@@ -2,6 +2,9 @@
 using System.Reflection;
 using Autofac.Core;
 using NLog;
+// ReSharper disable RedundantUsingDirective
+using Module = Autofac.Module;
+// ReSharper restore RedundantUsingDirective
 
 namespace Autofac.Extras.NLog
 {


### PR DESCRIPTION
Without this, on consumption, my app believes that NLogModule is a `System.Reflection.Module`, instead of an `Autofac.Module`, and so cannot be registered.
