### PR TITLE
'Trace' and 'TraceException' methods now present in ILogger interface.

### DIFF
--- a/src/Autofac.Extras.NLog/ILogger.cs
+++ b/src/Autofac.Extras.NLog/ILogger.cs
@@ -18,5 +18,8 @@ namespace Autofac.Extras.NLog
 
         void Fatal(string message);
         void FatalException(string message, Exception exception);
+
+        void Trace(string message);
+        void TraceException(string message, Exception exception);
     }
 }

--- a/src/Autofac.Extras.NLog/NLogger.cs
+++ b/src/Autofac.Extras.NLog/NLogger.cs
@@ -63,6 +63,16 @@ namespace Autofac.Extras.NLog
         {
             _logger.FatalException(message, exception);
         }
+
+        public void Trace(string message)
+        {
+            _logger.Trace(message);
+        }
+
+        public void TraceException(string message, Exception exception)
+        {
+            _logger.TraceException(message, exception);
+        }
         #endregion
     }
 }


### PR DESCRIPTION
 Also implemented in NLogger accordingly.
